### PR TITLE
Added stack yaml with a nix: section

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+resolver: lts-3.13
+nix:
+    enable: false
+    packages: [glpk]
+


### PR DESCRIPTION
In order to be able to build glpk-hs with Stack, even if GLPK is not installed on the system.
