### PR TITLE
Yet another attempt to make glpk-hs compile with newer versions of GHC

### DIFF
--- a/src/Data/LinearProgram/Common.hs
+++ b/src/Data/LinearProgram/Common.hs
@@ -13,7 +13,7 @@ import Data.Map
 import GHC.Exts (build)
 
 {-# RULES
-	"assocs" assocs = \ m -> build (\ c n -> foldWithKey (curry c) n m);
-	"elems" elems = \ m -> build (\ c n -> foldWithKey (const c) n m);
-	"keys" keys = \ m -> build (\ c n -> foldWithKey (\ k _ -> c k) n m);
+	"assocs" assocs = \ m -> build (\ c n -> foldrWithKey (curry c) n m);
+	"elems" elems = \ m -> build (\ c n -> foldrWithKey (const c) n m);
+	"keys" keys = \ m -> build (\ c n -> foldrWithKey (\ k _ -> c k) n m);
 	#-}

--- a/src/Data/LinearProgram/GLPK/Types.hs
+++ b/src/Data/LinearProgram/GLPK/Types.hs
@@ -4,6 +4,7 @@ module Data.LinearProgram.GLPK.Types where
 
 import Control.Concurrent (runInBoundThread)
 import Control.Exception (bracket)
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Trans (MonadIO (..))
 import Control.Monad (ap)
 
@@ -35,6 +36,8 @@ instance Monad GLPK where
         return x = GLP $ \ _ -> return x
         m >>= k = GLP $ \ lp -> do      x <- execGLPK m lp
                                         execGLPK (k x) lp
+instance Fail.MonadFail GLPK where
+        fail s = GLP . const $ Fail.fail s
 instance Functor GLPK where
   fmap f (GLP k) = GLP $ \p -> fmap f (k p)
 


### PR DESCRIPTION
As you probably noticed, the current version of glpk-hs (0.7) can't be built with GHC versions newer than 8.4 (cf. [Hackage build matrix](https://matrix.hackage.haskell.org/#/package/glpk-hs)). This commit  (which consists of replacing `foldWithKey` by `foldrWithKey` and defining a `MonadFail` instance) allows glpk-hs to be built with GHC 8.6 and 8.8 as well.

I'm aware that there are already other pull requests (#11, #13) which address this issue, but I'm hoping that you'd be more inclined to merge this minimal patch with no merge conflicts.

I tested the result with the following stack resolvers / GHC versions (and can provide build logs if needed):

* LTS 15.7 / ghc-8.8.3
* LTS 14.27 / ghc-8.6.5
* LTS 13.19 / ghc-8.6.4
* LTS 12.26 / ghc-8.4.4

(I didn't try earlier versions because gasp 1.2, which glpk-hs currently depends on, does not compile with GHC 8.2.)
