### PR TITLE
Change invocations of liftM to use fmap instead

### DIFF
--- a/src/Control/Monad/LPMonad/Internal.hs
+++ b/src/Control/Monad/LPMonad/Internal.hs
@@ -72,7 +72,7 @@ execLPM = runIdentity . execLPT
 
 -- | Constructs a linear programming problem in the specified monad.
 execLPT :: (Ord v, Group c, AbelianAdditive c, Monad m) => LPT v c m a -> m (LP v c)
-execLPT = liftM snd . runLPT
+execLPT = fmap snd . runLPT
 
 -- | Runs the specified operation in the linear programming monad.
 evalLPM :: (Ord v, Group c, AbelianAdditive c) => LPM v c a -> a
@@ -80,7 +80,7 @@ evalLPM = runIdentity . evalLPT
 
 -- | Runs the specified operation in the linear programming monad transformer.
 evalLPT :: (Ord v, Group c, AbelianAdditive c, Monad m) => LPT v c m a -> m a
-evalLPT = liftM fst . runLPT
+evalLPT = fmap fst . runLPT
 
 -- | Sets the optimization direction of the linear program: maximization or minimization.
 {-# SPECIALIZE setDirection :: Direction -> LPM v c (), Monad m => Direction -> LPT v c m () #-}


### PR DESCRIPTION
It has been a long time since Monads were not Functors.  This update fixes the build under GHC 9.10, where liftM no longer seems to be available in the usual place.